### PR TITLE
Cancel Damage From Pets

### DIFF
--- a/src/main/java/dansplugins/wildpets/config/ConfigService.java
+++ b/src/main/java/dansplugins/wildpets/config/ConfigService.java
@@ -73,6 +73,9 @@ public class ConfigService {
         if (!getConfig().isSet(configOptionsPrefix + "bornPetsEnabled")) {
             getConfig().set(configOptionsPrefix + "bornPetsEnabled", true);
         }
+        if (!getConfig().isSet(configOptionsPrefix + "damageFromPetsEnabled")) {
+            getConfig().set(configOptionsPrefix + "damageFromPetsEnabled", false);
+        }
 
         // save default entity configuration
         EntityConfig defaultEntityConfig = entityConfigService.getDefaultConfiguration();
@@ -126,7 +129,8 @@ public class ConfigService {
                     || option.equalsIgnoreCase("preventMountingLockedPets")
                     || option.equalsIgnoreCase("damageToPetsEnabled")
                     || option.equalsIgnoreCase("showLineageInfo")
-                    || option.equalsIgnoreCase("bornPetsEnabled")) {
+                    || option.equalsIgnoreCase("bornPetsEnabled")
+                    || option.equalsIgnoreCase("damageFromPetsEnabled")) {
                 getConfig().set(configOptionsPrefix + option, Boolean.parseBoolean(value));
                 sender.sendMessage(ChatColor.GREEN + "Boolean set.");
             } else if (option.equalsIgnoreCase("C")) { // no doubles yet
@@ -159,7 +163,8 @@ public class ConfigService {
                 + ", preventMountingLockedPets: " + getInt("preventMountingLockedPets")
                 + ", damageToPetsEnabled: " + getBoolean("damageToPetsEnabled")
                 + ", showLineageInfo: " + getBoolean("bornPetsEnabled")
-                + ", bornPetsEnabled: " + getBoolean("bornPetsEnabled"));
+                + ", bornPetsEnabled: " + getBoolean("bornPetsEnabled")
+                + ", damageFromPetsEnabled: " + getBoolean("damageFromPetsEnabled"));
         sender.sendMessage(ChatColor.AQUA + "====================");
         sender.sendMessage(ChatColor.AQUA + "Note: Entity configurations are not shown.");
         sender.sendMessage(ChatColor.AQUA + "====================");

--- a/src/main/java/dansplugins/wildpets/config/EntityConfigService.java
+++ b/src/main/java/dansplugins/wildpets/config/EntityConfigService.java
@@ -72,8 +72,8 @@ public class EntityConfigService {
         configurations.add(new EntityConfig("Strider", 0.5, Material.NETHER_WART, 32, true));
         configurations.add(new EntityConfig("Tropical_Fish", 0.5, Material.KELP, 24, true));
         configurations.add(new EntityConfig("Turtle", 0.5, Material.SEAGRASS, 16, true));
-        configurations.add(new EntityConfig("Villager", 0.5, Material.POTATO, 8, false));
-        configurations.add(new EntityConfig("Wandering Trader", 0.5, Material.GOLD_INGOT, 8, false));
+        configurations.add(new EntityConfig("Villager", 0.5, Material.POTATO, 8, true));
+        configurations.add(new EntityConfig("Wandering Trader", 0.5, Material.GOLD_INGOT, 8, true));
 
         // neutral mobs
         configurations.add(new EntityConfig("Bee", 0.5, Material.HONEYCOMB, 8, true));
@@ -91,42 +91,42 @@ public class EntityConfigService {
         configurations.add(new EntityConfig("Zombified_Piglin", 0.5, Material.NETHER_WART, 32, true));
 
         // hostile mobs
-        configurations.add(new EntityConfig("Blaze", 0.5, Material.BLAZE_ROD, 16, false));
-        configurations.add(new EntityConfig("Chicken_Jockey", 0.5, Material.BONE, 16, false));
-        configurations.add(new EntityConfig("Creeper", 0.5, Material.GUNPOWDER, 16, false));
-        configurations.add(new EntityConfig("Drowned", 0.5, Material.KELP, 16, false));
-        configurations.add(new EntityConfig("Elder_Guardian", 0.5, Material.GLOWSTONE, 32, false));
-        configurations.add(new EntityConfig("Endermite", 0.5, Material.ENDER_PEARL, 16, false));
-        configurations.add(new EntityConfig("Evoker", 0.5, Material.GOLD_INGOT, 16, false));
-        configurations.add(new EntityConfig("Endermite", 0.5, Material.ENDER_PEARL, 16, false));
-        configurations.add(new EntityConfig("Ghast", 0.5, Material.GHAST_TEAR, 16, false));
-        configurations.add(new EntityConfig("Guardian", 0.5, Material.GLOWSTONE, 16, false));
-        configurations.add(new EntityConfig("Hoglin", 0.5, Material.CRIMSON_ROOTS, 16, false));
-        configurations.add(new EntityConfig("Husk", 0.5, Material.SAND, 16, false));
-        configurations.add(new EntityConfig("Magma_Cube", 0.5, Material.MAGMA_CREAM, 16, false));
-        configurations.add(new EntityConfig("Phantom", 0.5, Material.SOUL_SAND, 16, false));
-        configurations.add(new EntityConfig("Piglin", 0.5, Material.GOLD_INGOT, 16, false));
-        configurations.add(new EntityConfig("Pillager", 0.5, Material.GOLD_INGOT, 16, false));
-        configurations.add(new EntityConfig("Ravager", 0.5, Material.GOLD_INGOT, 16, false));
-        configurations.add(new EntityConfig("Ravager_Jockey", 0.5, Material.GOLD_INGOT, 16, false));
-        configurations.add(new EntityConfig("Shulker", 0.5, Material.CHEST, 16, false));
-        configurations.add(new EntityConfig("Silverfish", 0.5, Material.STONE, 16, false));
-        configurations.add(new EntityConfig("Skeleton", 0.5, Material.ARROW, 16, false));
-        configurations.add(new EntityConfig("Skeleton_Horseman", 0.5, Material.ARROW, 32, false));
-        configurations.add(new EntityConfig("Slime", 0.5, Material.SLIME_BALL, 16, false));
-        configurations.add(new EntityConfig("Spider_Jockey", 0.5, Material.ARROW, 16, false));
-        configurations.add(new EntityConfig("Stray", 0.5, Material.ARROW, 16, false));
-        configurations.add(new EntityConfig("Vex", 0.5, Material.IRON_SWORD, 16, false));
-        configurations.add(new EntityConfig("Vindicator", 0.5, Material.EMERALD, 16, false));
-        configurations.add(new EntityConfig("Witch", 0.5, Material.BROWN_MUSHROOM, 16, false));
-        configurations.add(new EntityConfig("Wither_Skeleton", 0.5, Material.BONE, 16, false));
-        configurations.add(new EntityConfig("Zoglin", 0.5, Material.ROTTEN_FLESH, 16, false));
-        configurations.add(new EntityConfig("Zombie", 0.5, Material.ROTTEN_FLESH, 16, false));
-        configurations.add(new EntityConfig("Zombie_Villager", 0.5, Material.ROTTEN_FLESH, 16, false));
+        configurations.add(new EntityConfig("Blaze", 0.5, Material.BLAZE_ROD, 16, true));
+        configurations.add(new EntityConfig("Chicken_Jockey", 0.5, Material.BONE, 16, true));
+        configurations.add(new EntityConfig("Creeper", 0.5, Material.GUNPOWDER, 16, true));
+        configurations.add(new EntityConfig("Drowned", 0.5, Material.KELP, 16, true));
+        configurations.add(new EntityConfig("Elder_Guardian", 0.5, Material.GLOWSTONE, 32, true));
+        configurations.add(new EntityConfig("Endermite", 0.5, Material.ENDER_PEARL, 16, true));
+        configurations.add(new EntityConfig("Evoker", 0.5, Material.GOLD_INGOT, 16, true));
+        configurations.add(new EntityConfig("Endermite", 0.5, Material.ENDER_PEARL, 16, true));
+        configurations.add(new EntityConfig("Ghast", 0.5, Material.GHAST_TEAR, 16, true));
+        configurations.add(new EntityConfig("Guardian", 0.5, Material.GLOWSTONE, 16, true));
+        configurations.add(new EntityConfig("Hoglin", 0.5, Material.CRIMSON_ROOTS, 16, true));
+        configurations.add(new EntityConfig("Husk", 0.5, Material.SAND, 16, true));
+        configurations.add(new EntityConfig("Magma_Cube", 0.5, Material.MAGMA_CREAM, 16, true));
+        configurations.add(new EntityConfig("Phantom", 0.5, Material.SOUL_SAND, 16, true));
+        configurations.add(new EntityConfig("Piglin", 0.5, Material.GOLD_INGOT, 16, true));
+        configurations.add(new EntityConfig("Pillager", 0.5, Material.GOLD_INGOT, 16, true));
+        configurations.add(new EntityConfig("Ravager", 0.5, Material.GOLD_INGOT, 16, true));
+        configurations.add(new EntityConfig("Ravager_Jockey", 0.5, Material.GOLD_INGOT, 16, true));
+        configurations.add(new EntityConfig("Shulker", 0.5, Material.CHEST, 16, true));
+        configurations.add(new EntityConfig("Silverfish", 0.5, Material.STONE, 16, true));
+        configurations.add(new EntityConfig("Skeleton", 0.5, Material.ARROW, 16, true));
+        configurations.add(new EntityConfig("Skeleton_Horseman", 0.5, Material.ARROW, 32, true));
+        configurations.add(new EntityConfig("Slime", 0.5, Material.SLIME_BALL, 16, true));
+        configurations.add(new EntityConfig("Spider_Jockey", 0.5, Material.ARROW, 16, true));
+        configurations.add(new EntityConfig("Stray", 0.5, Material.ARROW, 16, true));
+        configurations.add(new EntityConfig("Vex", 0.5, Material.IRON_SWORD, 16, true));
+        configurations.add(new EntityConfig("Vindicator", 0.5, Material.EMERALD, 16, true));
+        configurations.add(new EntityConfig("Witch", 0.5, Material.BROWN_MUSHROOM, 16, true));
+        configurations.add(new EntityConfig("Wither_Skeleton", 0.5, Material.BONE, 16, true));
+        configurations.add(new EntityConfig("Zoglin", 0.5, Material.ROTTEN_FLESH, 16, true));
+        configurations.add(new EntityConfig("Zombie", 0.5, Material.ROTTEN_FLESH, 16, true));
+        configurations.add(new EntityConfig("Zombie_Villager", 0.5, Material.ROTTEN_FLESH, 16, true));
 
         // boss mobs
-        configurations.add(new EntityConfig("Ender_Dragon", 0.5, Material.ENDER_EYE, 64, false));
-        configurations.add(new EntityConfig("Wither", 0.5, Material.WITHER_SKELETON_SKULL, 16, false));
+        configurations.add(new EntityConfig("Ender_Dragon", 0.5, Material.ENDER_EYE, 64, true));
+        configurations.add(new EntityConfig("Wither", 0.5, Material.WITHER_SKELETON_SKULL, 16, true));
 
         return configurations;
     }

--- a/src/main/java/dansplugins/wildpets/listeners/DamageEffectsAndDeathHandler.java
+++ b/src/main/java/dansplugins/wildpets/listeners/DamageEffectsAndDeathHandler.java
@@ -10,6 +10,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 
@@ -54,6 +55,19 @@ public class DamageEffectsAndDeathHandler implements Listener {
             else {
                 if (wildPets.isDebugEnabled()) { System.out.println("[DEBUG] Something went wrong removing " + name + " from the persistent data."); }
             }
+        }
+    }
+
+    @EventHandler()
+    public void handle(EntityDamageByEntityEvent event) {
+        if (configService.getBoolean("damageFromPetsEnabled")) {
+            return;
+        }
+        // if attacker is a pet, cancel
+        Pet pet = petListRepository.getPet(event.getDamager());
+        if (pet != null) {
+            if (wildPets.isDebugEnabled()) { System.out.println("[DEBUG] Cancelling EntityDamageEvent event to protect an entity from " + pet.getName() + "."); }
+            event.setCancelled(true);
         }
     }
 }


### PR DESCRIPTION
## Problem
Hostile entities still damage their owners after being tamed.

## Solution
Damage from pets has been cancelled in the following instances:
- Directly
- Projectiles
- Thrown potions
- Area of effect potions

## Testing
This was tested locally.

## Relevant Issue
closes #262 