### PR TITLE
Added entity configs for Allay, Frog, Warden, Camel & Sniffer

### DIFF
--- a/src/main/java/dansplugins/wildpets/config/EntityConfigService.java
+++ b/src/main/java/dansplugins/wildpets/config/EntityConfigService.java
@@ -45,14 +45,17 @@ public class EntityConfigService {
         ArrayList<EntityConfig> configurations = new ArrayList<>();
 
         // passive mobs
+        configurations.add(new EntityConfig("Allay", 0.5, Material.COOKIE, 8, true));
         configurations.add(new EntityConfig("Axolotl", 0.5, Material.KELP, 16, true));
         configurations.add(new EntityConfig("Bat", 0.5, Material.PUMPKIN_PIE, 1, true));
+        configurations.add(new EntityConfig("Camel", 0.5, Material.CACTUS, 8, true));
         configurations.add(new EntityConfig("Cat", 0.5, Material.SALMON, 8, true));
         configurations.add(new EntityConfig("Chicken", 0.5, Material.WHEAT_SEEDS, 8, true));
         configurations.add(new EntityConfig("Cod", 0.5, Material.KELP, 16, true));
         configurations.add(new EntityConfig("Cow", 0.5, Material.WHEAT, 32, true));
         configurations.add(new EntityConfig("Donkey", 0.5, Material.CARROT, 8, true));
         configurations.add(new EntityConfig("Fox", 0.5, Material.SWEET_BERRIES, 8, true));
+        configurations.add(new EntityConfig("Frog", 0.5, Material.SLIME_BALL, 8, true));
         configurations.add(new EntityConfig("Glow_Squid", 0.5, Material.KELP, 24, true));
         configurations.add(new EntityConfig("Horse", 0.5, Material.APPLE, 8, true));
         configurations.add(new EntityConfig("Mooshroom", 0.5, Material.RED_MUSHROOM, 8, true));
@@ -67,6 +70,7 @@ public class EntityConfigService {
         configurations.add(new EntityConfig("Salmon", 0.5, Material.KELP, 24, true));
         configurations.add(new EntityConfig("Sheep", 0.5, Material.WHEAT, 8, true));
         configurations.add(new EntityConfig("Skeleton_Horse", 0.5, Material.BONE, 8, true));
+        configurations.add(new EntityConfig("Sniffer", 0.5, Material.GRASS, 32, true));
         configurations.add(new EntityConfig("Snow_Golem", 0.5, Material.SNOWBALL, 32, true));
         configurations.add(new EntityConfig("Squid", 0.5, Material.KELP, 24, true));
         configurations.add(new EntityConfig("Strider", 0.5, Material.NETHER_WART, 32, true));
@@ -118,6 +122,7 @@ public class EntityConfigService {
         configurations.add(new EntityConfig("Stray", 0.5, Material.ARROW, 16, true));
         configurations.add(new EntityConfig("Vex", 0.5, Material.IRON_SWORD, 16, true));
         configurations.add(new EntityConfig("Vindicator", 0.5, Material.EMERALD, 16, true));
+        configurations.add(new EntityConfig("Warden", 0.5, Material.TOTEM_OF_UNDYING, 1, true));
         configurations.add(new EntityConfig("Witch", 0.5, Material.BROWN_MUSHROOM, 16, true));
         configurations.add(new EntityConfig("Wither_Skeleton", 0.5, Material.BONE, 16, true));
         configurations.add(new EntityConfig("Zoglin", 0.5, Material.ROTTEN_FLESH, 16, true));

--- a/src/test/java/dansplugins/wildpets/config/EntityConfigTest.java
+++ b/src/test/java/dansplugins/wildpets/config/EntityConfigTest.java
@@ -1,0 +1,27 @@
+package dansplugins.wildpets.config;
+
+import org.bukkit.Material;
+import org.junit.Test;
+
+public class EntityConfigTest {
+
+    @Test
+    public void testInitialization() {
+        EntityConfig entityConfig = new EntityConfig("Chicken", 0.5, Material.KELP, 16, true);
+        assert(entityConfig.getType().equals("Chicken"));
+        assert(entityConfig.getChanceToSucceed() == 0.5);
+        assert(entityConfig.getRequiredTamingItem().equals(Material.KELP));
+        assert(entityConfig.getTamingItemAmount() == 16);
+        assert(entityConfig.isEnabled());
+    }
+
+    @Test
+    public void testInitialization_Disabled() {
+        EntityConfig entityConfig = new EntityConfig("Chicken", 0.5, Material.KELP, 16, false);
+        assert(entityConfig.getType().equals("Chicken"));
+        assert(entityConfig.getChanceToSucceed() == 0.5);
+        assert(entityConfig.getRequiredTamingItem().equals(Material.KELP));
+        assert(entityConfig.getTamingItemAmount() == 16);
+        assert(!entityConfig.isEnabled());
+    }
+}

--- a/src/test/java/dansplugins/wildpets/location/WpLocationTest.java
+++ b/src/test/java/dansplugins/wildpets/location/WpLocationTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 public class WpLocationTest {
 
     @Test
-    public void testConstructor() {
+    public void testInitialization() {
         WpLocation location = new WpLocation(0, 0, 0);
         assert(location.getX() == 0);
         assert(location.getY() == 0);


### PR DESCRIPTION
## Problem
More mobs have come out in recent updates of Minecraft, but the entity configurations haven't been updated in awhile.

## Solution
Entity configurations for the following mobs have been added:
- Allay
- Frog
- Warden
- Camel
- Sniffer

## Testing
- The unit tests have been verified to pass with these changes.
- Taming has been verified to work with each of the new entities with entity configurations.

![2024-03-23_07 33 17](https://github.com/Dans-Plugins/Wild-Pets/assets/21204351/55f732b6-be67-4c7a-b11d-73b225c0eef2)

## Relevant Issues
closes #254 
closes #255 
closes #256 
closes #259 
closes #260 